### PR TITLE
Source repository link added in the Plug-in Selection Spy

### DIFF
--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/PDERuntimeMessages.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/PDERuntimeMessages.java
@@ -66,6 +66,7 @@ public class PDERuntimeMessages extends NLS {
 	public static String SpyDialog_activeWizard_desc;
 	public static String SpyDialog_activeMenuIds;
 	public static String SpyDialog_contributingPluginId_title;
+	public static String SpyDialog_sourceRepository;
 	public static String SpyDialog_contributingPluginId_desc;
 	public static String SpyDialog_activeSelection_title;
 	public static String SpyDialog_activeSelection_desc;

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/pderuntimeresources.properties
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/pderuntimeresources.properties
@@ -78,6 +78,7 @@ SpyDialog_activePart_title = Active Part ({0})
 SpyDialog_activePart_desc = The active {0} class:
 SpyDialog_activeMenuIds = The active menu contribution identifiers:
 SpyDialog_contributingPluginId_title = The contributing plug-in:
+SpyDialog_sourceRepository = The source repository:
 SpyDialog_contributingPluginId_desc = The active {0} identifier:
 SpyDialog_activeSelection_title = Active Selection
 SpyDialog_activeSelection_desc = The selection class:

--- a/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/spy/sections/ActivePartSection.java
+++ b/ui/org.eclipse.pde.runtime/src/org/eclipse/pde/internal/runtime/spy/sections/ActivePartSection.java
@@ -114,7 +114,8 @@ public class ActivePartSection implements ISpySection {
 			bundle = FrameworkUtil.getBundle(mPart.getObject().getClass());
 		}
 
-		toolkit.generatePluginDetailsText(bundle, part.getSite().getId(), partType, buffer, text);
+		 toolkit.generatePluginDetailsText(bundle, part, partType, buffer,
+		 text);
 
 		// get menu information using reflection
 		try {


### PR DESCRIPTION
Added a link to the GitHub project.
Since it’s an external link, it currently opens in a new browser window.
This behavior could be updated to open the GitHub link in the Eclipse internal browser, for consistency with other internal links.